### PR TITLE
fix(adonis): disable explicit-member-accessibility rule

### DIFF
--- a/adonis.js
+++ b/adonis.js
@@ -30,6 +30,7 @@ module.exports = {
         pathGroupsExcludedImportTypes: ['builtin'],
       },
     ],
+    '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
   },


### PR DESCRIPTION
This rules isn't really useful in an application that has
no public TypeScript API.
